### PR TITLE
Update jquery.dom-outline-1.0.js

### DIFF
--- a/jquery.dom-outline-1.0.js
+++ b/jquery.dom-outline-1.0.js
@@ -4,24 +4,24 @@
  * Andrew Childs <ac@glomerate.com>
  *
  * Example Setup:
- * var myClickHandler = function (element) { console.log('Clicked element:', element); }
- * var myDomOutline = DomOutline({ onClick: myClickHandler, filter: '.debug' });
+ * let myClickHandler = function (element) { console.log('Clicked element:', element); }
+ * let myDomOutline = DomOutline({ onClick: myClickHandler, filter: '.debug' });
  *
  * Public API:
  * myDomOutline.start();
  * myDomOutline.stop();
  */
 var DomOutline = function (options) {
-    options = options || {};
-
-    var pub = {};
-    var self = {
-        opts: {
-            namespace: options.namespace || 'DomOutline',
-            borderWidth: options.borderWidth || 2,
-            onClick: options.onClick || false,
-            filter: options.filter || false
-        },
+    let pub = {};
+    let jsonSelf = {
+        opts: jQuery.extend({
+            // default options
+            namespace: 'DomOutline',
+            borderWidth: 2,
+            onClick: false,
+            filter: false,
+            stopWhenClicked: true
+        }, options || {}),
         keyCodes: {
             BACKSPACE: 8,
             ESC: 27,
@@ -33,7 +33,7 @@ var DomOutline = function (options) {
     };
 
     function writeStylesheet(css) {
-        var element = document.createElement('style');
+        let element = document.createElement('style');
         element.type = 'text/css';
         document.getElementsByTagName('head')[0].appendChild(element);
 
@@ -45,14 +45,14 @@ var DomOutline = function (options) {
     }
 
     function initStylesheet() {
-        if (self.initialized !== true) {
-            var css = '' +
-                '.' + self.opts.namespace + ' {' +
+        if (jsonSelf.initialized !== true) {
+            let css = '' +
+                '.' + jsonSelf.opts.namespace + ' {' +
                 '    background: #09c;' +
                 '    position: absolute;' +
                 '    z-index: 1000000;' +
                 '}' +
-                '.' + self.opts.namespace + '_label {' +
+                '.' + jsonSelf.opts.namespace + '_label {' +
                 '    background: #09c;' +
                 '    border-radius: 2px;' +
                 '    color: #fff;' +
@@ -64,26 +64,26 @@ var DomOutline = function (options) {
                 '}';
 
             writeStylesheet(css);
-            self.initialized = true;
+            jsonSelf.initialized = true;
         }
     }
 
     function createOutlineElements() {
-        self.elements.label = jQuery('<div></div>').addClass(self.opts.namespace + '_label').appendTo('body');
-        self.elements.top = jQuery('<div></div>').addClass(self.opts.namespace).appendTo('body');
-        self.elements.bottom = jQuery('<div></div>').addClass(self.opts.namespace).appendTo('body');
-        self.elements.left = jQuery('<div></div>').addClass(self.opts.namespace).appendTo('body');
-        self.elements.right = jQuery('<div></div>').addClass(self.opts.namespace).appendTo('body');
+        jsonSelf.elements.label = jQuery('<div></div>').addClass(jsonSelf.opts.namespace + '_label').appendTo('body');
+        jsonSelf.elements.top = jQuery('<div></div>').addClass(jsonSelf.opts.namespace).appendTo('body');
+        jsonSelf.elements.bottom = jQuery('<div></div>').addClass(jsonSelf.opts.namespace).appendTo('body');
+        jsonSelf.elements.left = jQuery('<div></div>').addClass(jsonSelf.opts.namespace).appendTo('body');
+        jsonSelf.elements.right = jQuery('<div></div>').addClass(jsonSelf.opts.namespace).appendTo('body');
     }
 
     function removeOutlineElements() {
-        jQuery.each(self.elements, function(name, element) {
+        jQuery.each(jsonSelf.elements, function(name, element) {
             element.remove();
         });
     }
 
     function compileLabelText(element, width, height) {
-        var label = element.tagName.toLowerCase();
+        let label = element.tagName.toLowerCase();
         if (element.id) {
             label += '#' + element.id;
         }
@@ -94,41 +94,41 @@ var DomOutline = function (options) {
     }
 
     function getScrollTop() {
-        if (!self.elements.window) {
-            self.elements.window = jQuery(window);
+        if (!jsonSelf.elements.window) {
+            jsonSelf.elements.window = jQuery(window);
         }
-        return self.elements.window.scrollTop();
+        return jsonSelf.elements.window.scrollTop();
     }
 
     function updateOutlinePosition(e) {
-        if (e.target.className.indexOf(self.opts.namespace) !== -1) {
+        if (e.target.className.indexOf(jsonSelf.opts.namespace) !== -1) {
             return;
         }
-        if (self.opts.filter) {
-            if (!jQuery(e.target).is(self.opts.filter)) {
+        if (jsonSelf.opts.filter) {
+            if (!jQuery(e.target).is(jsonSelf.opts.filter)) {
                 return;
             }
         }      
         pub.element = e.target;
 
-        var b = self.opts.borderWidth;
-        var scroll_top = getScrollTop();
-        var pos = pub.element.getBoundingClientRect();
-        var top = pos.top + scroll_top;
+        let b = jsonSelf.opts.borderWidth;
+        let scroll_top = getScrollTop();
+        let pos = pub.element.getBoundingClientRect();
+        let top = pos.top + scroll_top;
 
-        var label_text = compileLabelText(pub.element, pos.width, pos.height);
-        var label_top = Math.max(0, top - 20 - b, scroll_top);
-        var label_left = Math.max(0, pos.left - b);
+        let label_text = compileLabelText(pub.element, pos.width, pos.height);
+        let label_top = Math.max(0, top - 20 - b, scroll_top);
+        let label_left = Math.max(0, pos.left - b);
 
-        self.elements.label.css({ top: label_top, left: label_left }).text(label_text);
-        self.elements.top.css({ top: Math.max(0, top - b), left: pos.left - b, width: pos.width + b, height: b });
-        self.elements.bottom.css({ top: top + pos.height, left: pos.left - b, width: pos.width + b, height: b });
-        self.elements.left.css({ top: top - b, left: Math.max(0, pos.left - b), width: b, height: pos.height + b });
-        self.elements.right.css({ top: top - b, left: pos.left + pos.width, width: b, height: pos.height + (b * 2) });
+        jsonSelf.elements.label.css({ top: label_top, left: label_left }).text(label_text);
+        jsonSelf.elements.top.css({ top: Math.max(0, top - b), left: pos.left - b, width: pos.width + b, height: b });
+        jsonSelf.elements.bottom.css({ top: top + pos.height, left: pos.left - b, width: pos.width + b, height: b });
+        jsonSelf.elements.left.css({ top: top - b, left: Math.max(0, pos.left - b), width: b, height: pos.height + b });
+        jsonSelf.elements.right.css({ top: top - b, left: pos.left + pos.width, width: b, height: pos.height + (b * 2) });
     }
 
     function stopOnEscape(e) {
-        if (e.keyCode === self.keyCodes.ESC || e.keyCode === self.keyCodes.BACKSPACE || e.keyCode === self.keyCodes.DELETE) {
+        if (e.keyCode === jsonSelf.keyCodes.ESC || e.keyCode === jsonSelf.keyCodes.BACKSPACE || e.keyCode === jsonSelf.keyCodes.DELETE) {
             pub.stop();
         }
 
@@ -136,24 +136,24 @@ var DomOutline = function (options) {
     }
 
     function clickHandler(e) {
-        pub.stop();
-        self.opts.onClick(pub.element);
+        if (jsonSelf.opts.stopWhenClicked) pub.stop();
+        jsonSelf.opts.onClick(pub.element);
 
         return false;
     }
 
     pub.start = function () {
         initStylesheet();
-        if (self.active !== true) {
-            self.active = true;
+        if (jsonSelf.active !== true) {
+            jsonSelf.active = true;
             createOutlineElements();
-            jQuery('body').on('mousemove.' + self.opts.namespace, updateOutlinePosition);
-            jQuery('body').on('keyup.' + self.opts.namespace, stopOnEscape);
-            if (self.opts.onClick) {
+            jQuery('body').on('mousemove.' + jsonSelf.opts.namespace, updateOutlinePosition);
+            jQuery('body').on('keyup.' + jsonSelf.opts.namespace, stopOnEscape);
+            if (jsonSelf.opts.onClick) {
                 setTimeout(function () {
-                    jQuery('body').on('click.' + self.opts.namespace, function(e){
-                        if (self.opts.filter) {
-                            if (!jQuery(e.target).is(self.opts.filter)) {
+                    jQuery('body').on('click.' + jsonSelf.opts.namespace, function(e){
+                        if (jsonSelf.opts.filter) {
+                            if (!jQuery(e.target).is(jsonSelf.opts.filter)) {
                                 return false;
                             }
                         }
@@ -165,12 +165,18 @@ var DomOutline = function (options) {
     };
 
     pub.stop = function () {
-        self.active = false;
+        jsonSelf.active = false;
         removeOutlineElements();
-        jQuery('body').off('mousemove.' + self.opts.namespace)
-            .off('keyup.' + self.opts.namespace)
-            .off('click.' + self.opts.namespace);
+        jQuery('body').off('mousemove.' + jsonSelf.opts.namespace)
+            .off('keyup.' + jsonSelf.opts.namespace)
+            .off('click.' + jsonSelf.opts.namespace);
     };
+
+    Object.defineProperty(pub, 'onClick', {
+        set: function(rValue) {
+            jsonSelf.opts.onClick = rValue;
+        }
+    });
 
     return pub;
 };

--- a/jquery.dom-outline-1.0.js
+++ b/jquery.dom-outline-1.0.js
@@ -20,7 +20,6 @@ var DomOutline = function (options) {
             borderWidth: 2,
             onClick: false,
             filter: false,
-            stopWhenClicked: true
         }, options || {}),
         keyCodes: {
             BACKSPACE: 8,
@@ -136,9 +135,8 @@ var DomOutline = function (options) {
     }
 
     function clickHandler(e) {
-        if (jsonSelf.opts.stopWhenClicked) pub.stop();
-        jsonSelf.opts.onClick(pub.element);
-
+        // If the callback `onClick` returns false, stop outlining DOM element.
+        if (jsonSelf.opts.onClick(pub.element) === false) pub.stop();
         return false;
     }
 
@@ -175,6 +173,11 @@ var DomOutline = function (options) {
     Object.defineProperty(pub, 'onClick', {
         set: function(rValue) {
             jsonSelf.opts.onClick = rValue;
+        }
+    });
+    Object.defineProperty(pub, 'filter', {
+        set: function(rValue) {
+            jsonSelf.opts.filter = rValue;
         }
     });
 


### PR DESCRIPTION
Allow users to set/change `onClick` after function `DomOutline` returns, e.g. `let dom_outline = DomOutline(); dom_outline.onClick = function(elt) { do_something(); return false; };`. If the callback returns `false` it stop outlining DOM elements. Otherwise, the outlining will continue.